### PR TITLE
Fix sentry client bool check

### DIFF
--- a/moj_utils/templatetags/moj_utils.py
+++ b/moj_utils/templatetags/moj_utils.py
@@ -26,7 +26,7 @@ def field_from_name(form, name):
 @register.inclusion_tag('moj_utils/sentry-js.html')
 def sentry_js():
     sentry_dsn = None
-    if sentry_client:
+    if sentry_client is not None:
         sentry_dsn = sentry_client.get_public_dsn('https') or None
     return {
         'sentry_dsn': sentry_dsn

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-utils',
-    version='0.10',
+    version='0.11',
     packages=['moj_utils', 'moj_utils.templatetags'],
     include_package_data=True,
     license='BSD License',


### PR DESCRIPTION
Explicitly check if sentry_client is None instead of bool check, as the bool check for this type was causing an exception.
